### PR TITLE
Added section in user guide about load_json_dataset method

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -469,6 +469,20 @@ When frames are retrieved in image format, they can be converted into a *NumPy* 
 
 .. _cli:
 
+Loading JSON Data To ``pydicom``
+++++++++++++++++++++++++++++++++
+
+Load metadata from JSON format into a ``pydicom.dataset.Dataset`` object.
+A common use for this is translating metadata received from a ``RetrieveMetadata`` request:
+
+.. code-block:: python
+
+    from dicomweb_client import load_json_dataset
+
+    metadata = client.retrieve_study_metadata('1.2.826.0.1.3680043.8.1055.1.20111103111148288.98361414.79379639')
+    metadata_datasets = [load_json_dataset(ds) for ds in metadata]
+
+
 Command Line Interface (CLI)
 ----------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -473,11 +473,11 @@ Loading JSON Data To ``pydicom``
 ++++++++++++++++++++++++++++++++
 
 Load metadata from JSON format into a ``pydicom.dataset.Dataset`` object.
-A common use for this is translating metadata received from a ``RetrieveMetadata`` request:
+A common use for this is translating metadata received from a ``RetrieveMetadata`` or a ``SearchFor``-style request:
 
 .. code-block:: python
 
-    from dicomweb_client import load_json_dataset
+    from dicomweb_client.api import load_json_dataset
 
     metadata = client.retrieve_study_metadata('1.2.826.0.1.3680043.8.1055.1.20111103111148288.98361414.79379639')
     metadata_datasets = [load_json_dataset(ds) for ds in metadata]


### PR DESCRIPTION
There is currently no mention of the `load_json_dataset` method in the user guide. It provides functionality that may be very important for some users, but currently users may not know it exists.

This merge request adds a few lines of explanation and a small example to the user guide documentation